### PR TITLE
fix swiftkey reset during composing sync

### DIFF
--- a/lib/components/search/search_field.dart
+++ b/lib/components/search/search_field.dart
@@ -97,7 +97,12 @@ class _SearchFieldState extends State<SearchField> {
     _focusNode = FocusNode();
 
     if (!widget.isHome) {
-      searchTextSubscription = context.providers.listen(searchTextProvider, (_, text) => _controller.text = text);
+      searchTextSubscription = context.providers.listen(searchTextProvider, (_, text) {
+        // avoid IME restart by not mutating text during composing
+        if (_controller.text != text && !_controller.value.composing.isValid) {
+          _controller.text = text;
+        }
+      });
     }
 
     // autofocus on search screen


### PR DESCRIPTION
Na Androidu se při použití klávesnice Microsoft SwiftKey po každém zadání znaku do vyhledávacího pole resetuje její stav. Typicky při psaní číslic se přepne opět na textový layout, což je velmi nepříjemné při vyhledávání písní podle čísla.

S Flutterem běžně nepracuju, takže prosím promyslete, jestli úprava nemá nějaké vedlejší účinky. Pomohl jsem si s AI a cíl je eliminovat redundantní zpětné přepisování řetězce z provideru do controlleru. Asi kdyby aplikace nějak programově přepisovala hodnotu políčka během psaní, mohla by to moje úprava rozbít, jestli dobře chápu. Třeba vás napadne nějaké kvalitnější řešení. :)

Díky!